### PR TITLE
fix: 修复ios浏览器resizeObserver兼容性问题

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "dev": "vitepress dev",
+    "dev": "vitepress dev --host",
     "build:docs": "vitepress build",
     "docs:preview": "vitepress preview"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-virt-list",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Tiny(3kb) & Virtual scroll list & Huge amount data & High performance (support vue2.x&vue3.x)",
   "author": "keno-lee",
   "license": "MIT",

--- a/src/VirtList.tsx
+++ b/src/VirtList.tsx
@@ -492,11 +492,23 @@ function useVirtList<T extends Record<string, any>>(
 
         if (id) {
           const oldSize = getItemSize(id);
-          const newSize = props.horizontal
-            ? entry.borderBoxSize[0].inlineSize
-            : entry.borderBoxSize[0].blockSize;
 
-          // console.log(id, newSize);
+          let newSize = 0;
+          // 兼容性处理，详情：https://developer.mozilla.org/zh-CN/docs/Web/API/ResizeObserver
+          // ios中没有borderBoxSize，只有contentRect
+          if (entry.borderBoxSize) {
+            // Firefox implements `contentBoxSize` as a single content rect, rather than an array
+            const contentBoxSize = Array.isArray(entry.contentBoxSize)
+              ? entry.contentBoxSize[0]
+              : entry.contentBoxSize;
+            newSize = props.horizontal
+              ? contentBoxSize.inlineSize
+              : contentBoxSize.blockSize;
+          } else {
+            newSize = props.horizontal
+              ? entry.contentRect.width
+              : entry.contentRect.height;
+          }
 
           if (id === 'client') {
             slotSize.clientSize = newSize;


### PR DESCRIPTION
修复ios浏览器resizeObserver兼容性问题
- `contentRect` 仅在旧版本浏览器中生效，例如ios中（包含safari和chrome），其他浏览器应当使用 `contentBoxSize`
- Firefox 实现 `contentBoxSize` 是一个对象, 而其他浏览器是数组